### PR TITLE
Fix navbar dropdown overlap issue

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -190,16 +190,16 @@ body {
     transition: all 0.3s ease !important;
 }
 
-/* Header z-index to ensure elements appear on top */
+/* Header z-index - keep low to allow dropdowns to appear on top */
 .header,
 header {
     position: relative !important;
-    z-index: 1000 !important;
+    z-index: 100 !important;
 }
 
 .navbar-expand-md {
     position: relative !important;
-    z-index: 999 !important;
+    z-index: 100 !important;
 }
 
 .navbar-brand {
@@ -249,7 +249,7 @@ header {
     max-height: none !important;
     margin-top: 8px !important;
     padding: 8px 0 !important;
-    z-index: 1050 !important;
+    z-index: 2000 !important;
     position: absolute !important;
 }
 
@@ -257,7 +257,7 @@ header {
 .dropdown,
 .nav-item.dropdown {
     position: relative !important;
-    z-index: 1001 !important;
+    z-index: 1500 !important;
 }
 
 .dropdown-item {


### PR DESCRIPTION
Adjusted z-index values to ensure language and profile dropdowns appear above the dashboard/order/services navigation bar:
- Reduced header and navbar z-index from 999-1000 to 100
- Increased dropdown menu z-index from 1050 to 2000
- Increased dropdown container z-index from 1001 to 1500

This prevents the navigation bar from blocking dropdown menus.