### PR TITLE
Use smaller icons in mobile navbar

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -677,7 +677,7 @@ a:hover {
     align-items: center !important;
     justify-content: center !important;
     flex-shrink: 0 !important;
-    margin-right: 0.5rem !important;
+    margin-right: 0.25rem !important;
     width: 1.5rem !important;
     height: 1.5rem !important;
 }
@@ -1186,12 +1186,12 @@ select {
     }
 
     .navbar-nav .nav-link {
-        padding: 16px 20px !important;
-        min-height: 56px !important;
-        font-size: 16px !important;
+        padding: 12px 16px !important;
+        min-height: 48px !important;
+        font-size: 15px !important;
         display: flex !important;
         align-items: center !important;
-        gap: 0.75rem !important;
+        gap: 0.5rem !important;
         width: 100% !important;
         max-width: 100% !important;
         overflow: visible !important;
@@ -1199,17 +1199,18 @@ select {
         text-overflow: ellipsis !important;
     }
 
-    /* Mobile navbar icon sizing */
+    /* Mobile navbar icon sizing - smaller icons */
     .navbar-nav .nav-link .nav-link-icon {
         flex-shrink: 0 !important;
-        width: 1.5rem !important;
-        height: 1.5rem !important;
+        width: 1rem !important;
+        height: 1rem !important;
+        margin-right: 0.5rem !important;
     }
 
     .navbar-nav .nav-link .icon {
         flex-shrink: 0 !important;
-        width: 1.5rem !important;
-        height: 1.5rem !important;
+        width: 1rem !important;
+        height: 1rem !important;
     }
 
     /* Remove hover animation on mobile (conflicts with stacking) */
@@ -1231,9 +1232,9 @@ select {
     }
 
     .dropdown-item {
-        padding: 14px 32px !important;
-        min-height: 52px !important;
-        font-size: 15px !important;
+        padding: 10px 24px !important;
+        min-height: 44px !important;
+        font-size: 14px !important;
         width: 100% !important;
         max-width: 100% !important;
         overflow-x: hidden !important;


### PR DESCRIPTION
Reduced navbar icon sizes on mobile from 1.5rem (24px) to 1rem (16px) for better space utilization. Also reduced padding, min-height, font-size, and gaps to create a more compact and cleaner mobile navigation experience.