### PR TITLE
Improve mobile navbar layout with properly sized icons

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -1188,12 +1188,12 @@ select {
     }
 
     .navbar-nav .nav-link {
-        padding: 10px 12px !important;
-        min-height: 44px !important;
-        font-size: 14px !important;
+        padding: 12px 16px !important;
+        min-height: 48px !important;
+        font-size: 16px !important;
         display: flex !important;
         align-items: center !important;
-        gap: 0.25rem !important;
+        gap: 0.5rem !important;
         width: 100% !important;
         max-width: 100% !important;
         overflow: visible !important;
@@ -1201,19 +1201,19 @@ select {
         text-overflow: ellipsis !important;
     }
 
-    /* Mobile navbar icon sizing - very small icons without padding */
+    /* Mobile navbar icon sizing - properly sized icons */
     .navbar-nav .nav-link .nav-link-icon {
         flex-shrink: 0 !important;
-        width: 0.75rem !important;
-        height: 0.75rem !important;
-        margin-right: 0.25rem !important;
+        width: 1rem !important;
+        height: 1rem !important;
+        margin-right: 0.5rem !important;
         padding: 0 !important;
     }
 
     .navbar-nav .nav-link .icon {
         flex-shrink: 0 !important;
-        width: 0.75rem !important;
-        height: 0.75rem !important;
+        width: 1rem !important;
+        height: 1rem !important;
         padding: 0 !important;
     }
 


### PR DESCRIPTION
- Increased icon size from 0.75rem (12px) to 1rem (16px) for better visibility
- Increased nav link padding from 10px 12px to 12px 16px for better touch targets
- Increased font size from 14px to 16px for better readability
- Increased gap between icons and text from 0.25rem to 0.5rem
- Increased min-height from 44px to 48px for better accessibility

Each menu item is now displayed as its own full-width row with proper spacing and borders, making the mobile navigation much more usable.